### PR TITLE
#47 style: rice_ball_card四隅が丸くなるように修正

### DIFF
--- a/app/views/rice_balls/_rice_ball.html.erb
+++ b/app/views/rice_balls/_rice_ball.html.erb
@@ -1,4 +1,4 @@
-<div class="card bg-base-100 shadow-lg max-w-xl hover:border-primary hover:border">
+<div class="card bg-base-100 shadow-lg max-w-xl overflow-hidden hover:border-primary hover:border">
   <%= link_to "", rice_ball_path(rice_ball), class: "absolute top-0 left-0 right-0 bottom-0" %>
   <figure>
     <% if rice_ball.image.attached? %>


### PR DESCRIPTION
## 概要
rice_ball_card四隅が丸くなるように修正。overflow-hiddenを追加