### PR TITLE
#78 chore: non-root user権限付与

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ COPY --from=build /rails /rails
 # Run and own only the runtime files as a non-root user for security
 RUN groupadd --system --gid 1000 rails && \
     useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
-    chown -R rails:rails db log storage tmp
+    chown -R rails:rails db log storage tmp public/robots.txt public/sitemap.xml.gz
 USER 1000:1000
 
 # Entrypoint prepares the database.


### PR DESCRIPTION
## 概要
bundle exec rake sitemap:refreshをcron job(render.com)で実行できるように、
public/robots.txt public/sitemap.xml.gzの権限をnon-root userに付与