### PR TITLE
#88 chore: gem daemons

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem "aws-sdk-s3", require: false
 gem "sitemap_generator"
 
 gem "delayed_job_active_record"
+gem "daemons"
 
 gem "meta-tags"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
+    daemons (1.4.1)
     date (3.4.1)
     debug (1.10.0)
       irb (~> 1.10)
@@ -428,6 +429,7 @@ DEPENDENCIES
   capybara
   capybara-playwright-driver
   cssbundling-rails
+  daemons
   debug
   delayed_job_active_record
   devise


### PR DESCRIPTION
## 概要
下記エラーが、render.com workerで発生したので、gem "daemons"を導入する
You need to add gem 'daemons' to your Gemfile if you wish to use it. (RuntimeError)
