### PR TITLE
#98 add: render.com_default_url

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,7 +95,8 @@ Rails.application.configure do
   # Enable DNS rebinding protection and other `Host` header attacks.
   config.hosts = [
     "rice-ball-recipe.com",
-    "www.rice-ball-recipe.com"
+    "www.rice-ball-recipe.com",
+    "rice-ball-recipe-web.onrender.com"
   ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }


### PR DESCRIPTION
## 概要
Render のデフォルト URLのアクセスを許可する
